### PR TITLE
Add PHP 8 on travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
We have to wait until PHP 8.0 is officially available on Travis.

Linked issues/PR: https://github.com/php-build/php-build/pull/651 and https://travis-ci.community/t/php-8-0-missing/10132/15.