### PR TITLE
Fix calculator name normalization

### DIFF
--- a/test/CalculatorTest.php
+++ b/test/CalculatorTest.php
@@ -275,6 +275,45 @@ class CalculatorTest extends \PHPUnit\Framework\TestCase
             -1,
             'LSINLS80D44H501F',
           ),
+          array(
+            new Subject(
+                array(
+                'name' => "Marco—Antonio",
+                'surname' => "D’Andrea",
+                'birthDate' => '1990-01-01',
+                'gender' => 'M',
+                'belfioreCode' => 'F839',
+                )
+            ),
+            -1,
+            'DNDMCN90A01F839X',
+          ),
+          array(
+            new Subject(
+                array(
+                'name' => "Anna",
+                'surname' => "Betaña",
+                'birthDate' => '1972-04-02',
+                'gender' => 'F',
+                'belfioreCode' => 'H501',
+                )
+            ),
+            -1,
+            'BTENNA72D42H501M',
+          ),
+          array(
+            new Subject(
+                array(
+                'name' => "Žáç",
+                'surname' => "Öß",
+                'birthDate' => '1954-07-01',
+                'gender' => 'M',
+                'belfioreCode' => 'A794',
+                )
+            ),
+            -1,
+            'SSOZCA54L01A794X',
+          ),
         );
     }
 


### PR DESCRIPTION
fix #54 (and some other edge cases)

For what I was able to understand from official source, and verify with very limited real cases, only a specific subset of characters with accents or diacritics are transliterated.

eg: Ž is considered as Z, but ñ is not whitelested so is ignored

Refs: 
- https://www.agenziaentrate.gov.it/portale/documents/20143/299856/Circolare+34+del+20+07+2011_circolare+34e.pdf/
- https://dait.interno.gov.it/documenti/circolare-n-1-2008-0.pdf
