### PR TITLE
Fix PHP 8.1 DateTime null parameter constructor deprecation

### DIFF
--- a/src/Subject.php
+++ b/src/Subject.php
@@ -111,7 +111,7 @@ class Subject
     public function setBirthDate($birthDate)
     {
         if (!$birthDate instanceof DateTimeInterface) {
-            $birthDate = new DateTime($birthDate);
+            $birthDate = null !== $birthDate ? new DateTime($birthDate) : new DateTime();
         }
 
         $this->birthDate = $birthDate;


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php
```Deprecated: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated```
These changes avoid the deprecation warning by keeping the library behavior unchanged.

